### PR TITLE
delete param rule init

### DIFF
--- a/src/adservice-v2/src/main/java/org/daocloud/springcloud/adservice/controller/SentinelRuleDemo.java
+++ b/src/adservice-v2/src/main/java/org/daocloud/springcloud/adservice/controller/SentinelRuleDemo.java
@@ -69,7 +69,6 @@ public class SentinelRuleDemo {
             @RequestParam(required = false) String a,
             @RequestParam(required = false) String b
     ) {
-        initParamFlowRules();
         Entry entry = null;
         try {
             entry = SphU.entry("hot-test", EntryType.IN, 1, a, b);


### PR DESCRIPTION
server is now already persist the rules, and client can get the persist rules, so client can delete the memory init rules.